### PR TITLE
Add manual trigger for npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,7 @@
 name: NPM Package Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
- enable `workflow_dispatch` on npm publish workflow

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684dc2f758208322aad81d166aff2411