### PR TITLE
Add URL state sync for filters

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,11 @@ export default [
         require: true,
         process: true,
         setTimeout: true,
+        clearTimeout: true,
         IntersectionObserver: true,
+        URL: true,
+        URLSearchParams: true,
+        Event: true,
       },
     },
     rules: {
@@ -34,6 +38,20 @@ export default [
           bracketSpacing: true,
         },
       ],
+    },
+  },
+  {
+    files: ['**/__tests__/**/*.js', '**/*.test.js'],
+    languageOptions: {
+      globals: {
+        jest: true,
+        describe: true,
+        beforeEach: true,
+        afterEach: true,
+        test: true,
+        expect: true,
+        it: true,
+      },
     },
   },
 ];

--- a/src/__tests__/unit/FilterCheckboxManager.test.js
+++ b/src/__tests__/unit/FilterCheckboxManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 import FilterCheckboxManager from '../../filters/filter-checkbox';
 import { jest } from '@jest/globals';
 

--- a/src/__tests__/unit/FilterChipsManager.test.js
+++ b/src/__tests__/unit/FilterChipsManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 import FilterChipsManager from '../../filters/filter-chips';
 import Wized from '../../__mocks__/wized';
 

--- a/src/__tests__/unit/FilterPaginationManager.test.js
+++ b/src/__tests__/unit/FilterPaginationManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 import FilterPaginationManager from '../../filters/filter-pagination';
 import Wized from '../../__mocks__/wized';
 

--- a/src/__tests__/unit/FilterRadioManager.test.js
+++ b/src/__tests__/unit/FilterRadioManager.test.js
@@ -1,8 +1,6 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import FilterRadioManager from '../../filters/filter-radio';
 
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 import Wized from '../../__mocks__/wized';
 
 describe('FilterRadioManager', () => {

--- a/src/__tests__/unit/FilterResetManager.test.js
+++ b/src/__tests__/unit/FilterResetManager.test.js
@@ -1,5 +1,3 @@
-/* global jest, describe, beforeEach, it, expect */
-
 import FilterResetManager from '../../filters/filter-reset';
 import Wized from '../../__mocks__/wized';
 

--- a/src/__tests__/unit/FilterSearchManager.test.js
+++ b/src/__tests__/unit/FilterSearchManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest, Event */
-
 import Wized from '../../__mocks__/wized';
 import FilterSearchManager from '../../filters/filter-search';
 

--- a/src/__tests__/unit/FilterSelectManager.test.js
+++ b/src/__tests__/unit/FilterSelectManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 jest.mock('../../filters/filter-select');
 import { FilterSelectManager } from '../../filters/filter-select';
 import Wized from '../../__mocks__/wized';

--- a/src/__tests__/unit/FilterSelectRangeManager.test.js
+++ b/src/__tests__/unit/FilterSelectRangeManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest */
-
 jest.mock('../../filters/filter-select-range');
 import { FilterSelectRangeManager } from '../../filters/filter-select-range';
 import Wized from '../../__mocks__/wized';

--- a/src/__tests__/unit/FilterSortManager.test.js
+++ b/src/__tests__/unit/FilterSortManager.test.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, afterEach, test, expect, jest, Event */
-
 import FilterSortManager from '../../filters/filter-sort';
 import Wized from '../../__mocks__/wized';
 

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -1,9 +1,4 @@
-/* global describe, beforeEach, afterEach, test, expect */
-import {
-  applyUrlParamsToWized,
-  updateUrlFromWized,
-  syncInputsFromWized,
-} from '../../utils/url-sync.js';
+import { applyUrlParamsToWized, updateUrlFromWized } from '../../utils/url-sync.js';
 
 // Helper to mock window.location
 function setSearch(search) {
@@ -72,9 +67,11 @@ describe('URL Sync Utilities', () => {
   test('updateUrlFromWized writes variables to query string', () => {
     const Wized = { data: { v: { foo: 'bar', empty: '', list: ['a', 'b'] } } };
     setSearch('');
-    const replaceSpy = jest.spyOn(window.history, 'replaceState').mockImplementation((_, __, url) => {
-      window.location = new URL(`https://example.com${url}`);
-    });
+    const replaceSpy = jest
+      .spyOn(window.history, 'replaceState')
+      .mockImplementation((_, __, url) => {
+        window.location = new URL(`https://example.com${url}`);
+      });
     updateUrlFromWized(Wized);
     expect(replaceSpy).toHaveBeenCalled();
     expect(window.location.search).toBe('?foo=bar&list=a%2Cb');

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -1,0 +1,83 @@
+/* global describe, beforeEach, afterEach, test, expect */
+import {
+  applyUrlParamsToWized,
+  updateUrlFromWized,
+  syncInputsFromWized,
+} from '../../utils/url-sync.js';
+
+// Helper to mock window.location
+function setSearch(search) {
+  delete window.location;
+  window.location = new URL(`https://example.com/${search}`);
+}
+
+describe('URL Sync Utilities', () => {
+  let originalLocation;
+  beforeEach(() => {
+    originalLocation = window.location;
+    setSearch('');
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  test('applyUrlParamsToWized sets variables from query string', () => {
+    setSearch('?foo=bar&list=a,b');
+    const Wized = { data: { v: { foo: '', list: [] } } };
+    applyUrlParamsToWized(Wized);
+    expect(Wized.data.v.foo).toBe('bar');
+    expect(Wized.data.v.list).toEqual(['a', 'b']);
+  });
+
+  test('applyUrlParamsToWized populates inputs with values', () => {
+    document.body.innerHTML = '';
+
+    const searchInput = document.createElement('input');
+    searchInput.setAttribute('w-filter-search-variable', 'foo');
+
+    const labelA = document.createElement('label');
+    labelA.setAttribute('w-filter-checkbox-variable', 'list');
+    const customA = document.createElement('div');
+    customA.classList.add('w-checkbox-input--inputType-custom');
+    const textA = document.createElement('span');
+    textA.setAttribute('w-filter-checkbox-label', '');
+    textA.textContent = 'a';
+    labelA.appendChild(customA);
+    labelA.appendChild(textA);
+
+    const labelB = document.createElement('label');
+    labelB.setAttribute('w-filter-checkbox-variable', 'list');
+    const customB = document.createElement('div');
+    customB.classList.add('w-checkbox-input--inputType-custom');
+    const textB = document.createElement('span');
+    textB.setAttribute('w-filter-checkbox-label', '');
+    textB.textContent = 'b';
+    labelB.appendChild(customB);
+    labelB.appendChild(textB);
+
+    document.body.appendChild(searchInput);
+    document.body.appendChild(labelA);
+    document.body.appendChild(labelB);
+
+    setSearch('?foo=bar&list=a,b');
+    const Wized = { data: { v: { foo: '', list: [] } } };
+    applyUrlParamsToWized(Wized);
+
+    expect(searchInput.value).toBe('bar');
+    expect(customA.classList.contains('w--redirected-checked')).toBe(true);
+    expect(customB.classList.contains('w--redirected-checked')).toBe(true);
+  });
+
+  test('updateUrlFromWized writes variables to query string', () => {
+    const Wized = { data: { v: { foo: 'bar', empty: '', list: ['a', 'b'] } } };
+    setSearch('');
+    const replaceSpy = jest.spyOn(window.history, 'replaceState').mockImplementation((_, __, url) => {
+      window.location = new URL(`https://example.com${url}`);
+    });
+    updateUrlFromWized(Wized);
+    expect(replaceSpy).toHaveBeenCalled();
+    expect(window.location.search).toBe('?foo=bar&list=a%2Cb');
+    replaceSpy.mockRestore();
+  });
+});

--- a/src/filters/filter-search.js
+++ b/src/filters/filter-search.js
@@ -1,5 +1,3 @@
-/* global clearTimeout, Event */
-
 /**
  * FilterSearchManager: Main class responsible for managing search-based filtering functionality
  *

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import FilterSortManager from './filters/filter-sort.js';
 import FilterPaginationManager from './filters/filter-pagination.js';
 import FilterResetManager from './filters/filter-reset.js';
 import FilterSearchManager from './filters/filter-search.js';
+import { initUrlSync } from './utils/url-sync.js';
 
 // Export all components
 export { FilterCheckboxManager };
@@ -23,6 +24,9 @@ export { FilterSearchManager };
 if (typeof window !== 'undefined') {
   window.Wized = window.Wized || [];
   window.Wized.push((Wized) => {
+    // Sync filters with URL parameters
+    initUrlSync(Wized);
+
     // Initialize chips manager first since other managers depend on it
     new FilterChipsManager(Wized);
 

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -5,23 +5,17 @@ export function syncInputsFromWized(Wized) {
     const arrValue = Array.isArray(value) ? value : [value];
 
     // Search inputs
-    document
-      .querySelectorAll(`input[w-filter-search-variable="${key}"]`)
-      .forEach((input) => {
-        input.value = Array.isArray(value) ? value.join(',') : `${value}`;
-      });
+    document.querySelectorAll(`input[w-filter-search-variable="${key}"]`).forEach((input) => {
+      input.value = Array.isArray(value) ? value.join(',') : `${value}`;
+    });
 
     // Simple selects
-    document
-      .querySelectorAll(`select[w-filter-select-variable="${key}"]`)
-      .forEach((select) => {
-        select.value = `${value}`;
-      });
+    document.querySelectorAll(`select[w-filter-select-variable="${key}"]`).forEach((select) => {
+      select.value = `${value}`;
+    });
 
     // Range selects
-    const [fromVal, toVal] = Array.isArray(value)
-      ? value
-      : `${value}`.split(',');
+    const [fromVal, toVal] = Array.isArray(value) ? value : `${value}`.split(',');
 
     document
       .querySelectorAll(`select[w-filter-select-range-from-variable="${key}"]`)
@@ -36,34 +30,30 @@ export function syncInputsFromWized(Wized) {
       });
 
     // Checkboxes
-    document
-      .querySelectorAll(`label[w-filter-checkbox-variable="${key}"]`)
-      .forEach((label) => {
-        const text = label.querySelector('[w-filter-checkbox-label]')?.textContent || '';
-        const custom = label.querySelector('.w-checkbox-input--inputType-custom');
-        if (custom) {
-          if (arrValue.includes(text)) {
-            custom.classList.add('w--redirected-checked');
-          } else {
-            custom.classList.remove('w--redirected-checked');
-          }
+    document.querySelectorAll(`label[w-filter-checkbox-variable="${key}"]`).forEach((label) => {
+      const text = label.querySelector('[w-filter-checkbox-label]')?.textContent || '';
+      const custom = label.querySelector('.w-checkbox-input--inputType-custom');
+      if (custom) {
+        if (arrValue.includes(text)) {
+          custom.classList.add('w--redirected-checked');
+        } else {
+          custom.classList.remove('w--redirected-checked');
         }
-      });
+      }
+    });
 
     // Radios
-    document
-      .querySelectorAll(`label[w-filter-radio-variable="${key}"]`)
-      .forEach((label) => {
-        const text = label.querySelector('[w-filter-radio-label]')?.textContent || '';
-        const custom = label.querySelector('.w-form-formradioinput--inputType-custom');
-        if (custom) {
-          if (value === text) {
-            custom.classList.add('w--redirected-checked');
-          } else {
-            custom.classList.remove('w--redirected-checked');
-          }
+    document.querySelectorAll(`label[w-filter-radio-variable="${key}"]`).forEach((label) => {
+      const text = label.querySelector('[w-filter-radio-label]')?.textContent || '';
+      const custom = label.querySelector('.w-form-formradioinput--inputType-custom');
+      if (custom) {
+        if (value === text) {
+          custom.classList.add('w--redirected-checked');
+        } else {
+          custom.classList.remove('w--redirected-checked');
         }
-      });
+      }
+    });
   });
 }
 
@@ -98,8 +88,7 @@ export function updateUrlFromWized(Wized) {
       params.set(key, value);
     }
   });
-  const newUrl =
-    window.location.pathname + (params.toString() ? `?${params.toString()}` : '');
+  const newUrl = window.location.pathname + (params.toString() ? `?${params.toString()}` : '');
   window.history.replaceState({}, '', newUrl);
 }
 

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -1,0 +1,109 @@
+export function syncInputsFromWized(Wized) {
+  if (typeof window === 'undefined') return;
+
+  Object.entries(Wized.data.v).forEach(([key, value]) => {
+    const arrValue = Array.isArray(value) ? value : [value];
+
+    // Search inputs
+    document
+      .querySelectorAll(`input[w-filter-search-variable="${key}"]`)
+      .forEach((input) => {
+        input.value = Array.isArray(value) ? value.join(',') : `${value}`;
+      });
+
+    // Simple selects
+    document
+      .querySelectorAll(`select[w-filter-select-variable="${key}"]`)
+      .forEach((select) => {
+        select.value = `${value}`;
+      });
+
+    // Range selects
+    const [fromVal, toVal] = Array.isArray(value)
+      ? value
+      : `${value}`.split(',');
+
+    document
+      .querySelectorAll(`select[w-filter-select-range-from-variable="${key}"]`)
+      .forEach((select) => {
+        if (fromVal) select.value = fromVal;
+      });
+
+    document
+      .querySelectorAll(`select[w-filter-select-range-to-variable="${key}"]`)
+      .forEach((select) => {
+        if (toVal) select.value = toVal;
+      });
+
+    // Checkboxes
+    document
+      .querySelectorAll(`label[w-filter-checkbox-variable="${key}"]`)
+      .forEach((label) => {
+        const text = label.querySelector('[w-filter-checkbox-label]')?.textContent || '';
+        const custom = label.querySelector('.w-checkbox-input--inputType-custom');
+        if (custom) {
+          if (arrValue.includes(text)) {
+            custom.classList.add('w--redirected-checked');
+          } else {
+            custom.classList.remove('w--redirected-checked');
+          }
+        }
+      });
+
+    // Radios
+    document
+      .querySelectorAll(`label[w-filter-radio-variable="${key}"]`)
+      .forEach((label) => {
+        const text = label.querySelector('[w-filter-radio-label]')?.textContent || '';
+        const custom = label.querySelector('.w-form-formradioinput--inputType-custom');
+        if (custom) {
+          if (value === text) {
+            custom.classList.add('w--redirected-checked');
+          } else {
+            custom.classList.remove('w--redirected-checked');
+          }
+        }
+      });
+  });
+}
+
+export function applyUrlParamsToWized(Wized) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  params.forEach((value, key) => {
+    const current = Wized.data.v[key];
+    if (Array.isArray(current)) {
+      Wized.data.v[key] = value ? value.split(',') : [];
+    } else if (typeof current === 'number') {
+      const num = Number(value);
+      Wized.data.v[key] = Number.isNaN(num) ? current : num;
+    } else {
+      Wized.data.v[key] = value;
+    }
+  });
+
+  syncInputsFromWized(Wized);
+}
+
+export function updateUrlFromWized(Wized) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams();
+  Object.entries(Wized.data.v).forEach(([key, value]) => {
+    if (value === null || typeof value === 'undefined') return;
+    if (Array.isArray(value)) {
+      if (value.length > 0) params.set(key, value.join(','));
+    } else if (typeof value === 'number') {
+      if (value !== 0) params.set(key, value.toString());
+    } else if (value !== '') {
+      params.set(key, value);
+    }
+  });
+  const newUrl =
+    window.location.pathname + (params.toString() ? `?${params.toString()}` : '');
+  window.history.replaceState({}, '', newUrl);
+}
+
+export function initUrlSync(Wized) {
+  applyUrlParamsToWized(Wized);
+  Wized.on('requestend', () => updateUrlFromWized(Wized));
+}


### PR DESCRIPTION
## Summary
- add utility to sync filter selections with URL parameters
- initialize URL synchronization when Wized loads
- test URL sync helpers
- extend URL sync to update visible inputs

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc85764c88322bf8061ccff331d3a