### PR TITLE
Release v1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2025-06-14
+
+### Added
+
+- Add URL state sync for filters.
+
 ## [1.0.19] - 2025-03-01
 
 ### Added
 
 - There was an issue when changing radio selection, which is now fixed.
 
+[1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20
 [1.0.19]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",


### PR DESCRIPTION
## Summary
- bump lockfile version
- document URL sync feature in `CHANGELOG.md`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dcde3b5088322b93d3d4c25316fa0