### PR TITLE
Fix url sync logic for filter variables

### DIFF
--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -18,6 +18,16 @@ describe('URL Sync Utilities', () => {
   });
 
   test('applyUrlParamsToWized sets variables from query string', () => {
+    document.body.innerHTML = '';
+    const searchInput = document.createElement('input');
+    searchInput.setAttribute('w-filter-search-variable', 'foo');
+
+    const checkbox = document.createElement('label');
+    checkbox.setAttribute('w-filter-checkbox-variable', 'list');
+
+    document.body.appendChild(searchInput);
+    document.body.appendChild(checkbox);
+
     setSearch('?foo=bar&list=a,b');
     const Wized = { data: { v: { foo: '', list: [] } } };
     applyUrlParamsToWized(Wized);
@@ -64,8 +74,32 @@ describe('URL Sync Utilities', () => {
     expect(customB.classList.contains('w--redirected-checked')).toBe(true);
   });
 
+  test('syncInputsFromWized uses empty string for null values', () => {
+    document.body.innerHTML = '';
+
+    const searchInput = document.createElement('input');
+    searchInput.setAttribute('w-filter-search-variable', 'foo');
+
+    document.body.appendChild(searchInput);
+
+    const Wized = { data: { v: { foo: null } } };
+    applyUrlParamsToWized(Wized);
+
+    expect(searchInput.value).toBe('');
+  });
+
   test('updateUrlFromWized writes variables to query string', () => {
-    const Wized = { data: { v: { foo: 'bar', empty: '', list: ['a', 'b'] } } };
+    document.body.innerHTML = '';
+    const searchInput = document.createElement('input');
+    searchInput.setAttribute('w-filter-search-variable', 'foo');
+    const checkbox = document.createElement('label');
+    checkbox.setAttribute('w-filter-checkbox-variable', 'list');
+    document.body.appendChild(searchInput);
+    document.body.appendChild(checkbox);
+
+    const Wized = {
+      data: { v: { foo: 'bar', empty: '', list: ['a', 'b'], extra: 'x' } },
+    };
     setSearch('');
     const replaceSpy = jest
       .spyOn(window.history, 'replaceState')

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -1,21 +1,67 @@
+function getFilterVariableNames() {
+  if (typeof document === 'undefined') return new Set();
+
+  const selectors = [
+    '[w-filter-search-variable]',
+    '[w-filter-select-variable]',
+    '[w-filter-select-range-from-variable]',
+    '[w-filter-select-range-to-variable]',
+    '[w-filter-checkbox-variable]',
+    '[w-filter-radio-variable]',
+    '[w-filter-sort-variable]',
+  ];
+
+  const elements = document.querySelectorAll(selectors.join(','));
+  const names = new Set();
+
+  elements.forEach((el) => {
+    const attrs = [
+      'w-filter-search-variable',
+      'w-filter-select-variable',
+      'w-filter-select-range-from-variable',
+      'w-filter-select-range-to-variable',
+      'w-filter-checkbox-variable',
+      'w-filter-radio-variable',
+      'w-filter-sort-variable',
+    ];
+
+    attrs.forEach((attr) => {
+      if (el.hasAttribute(attr)) {
+        names.add(el.getAttribute(attr));
+      }
+    });
+  });
+
+  return names;
+}
+
 export function syncInputsFromWized(Wized) {
   if (typeof window === 'undefined') return;
 
   Object.entries(Wized.data.v).forEach(([key, value]) => {
-    const arrValue = Array.isArray(value) ? value : [value];
+    const normalized = value == null ? '' : value;
+    const arrValue = Array.isArray(normalized) ? normalized : [normalized];
 
     // Search inputs
-    document.querySelectorAll(`input[w-filter-search-variable="${key}"]`).forEach((input) => {
-      input.value = Array.isArray(value) ? value.join(',') : `${value}`;
-    });
+    document
+      .querySelectorAll(`input[w-filter-search-variable="${key}"]`)
+      .forEach((input) => {
+        input.value = Array.isArray(normalized)
+          ? normalized.join(',')
+          : `${normalized}`;
+      });
 
     // Simple selects
-    document.querySelectorAll(`select[w-filter-select-variable="${key}"]`).forEach((select) => {
-      select.value = `${value}`;
-    });
+    document
+      .querySelectorAll(`select[w-filter-select-variable="${key}"]`)
+      .forEach((select) => {
+        select.value = `${normalized}`;
+      });
 
     // Range selects
-    const [fromVal, toVal] = Array.isArray(value) ? value : `${value}`.split(',');
+    const [fromVal, toVal] = Array.isArray(normalized)
+      ? normalized
+      : `${normalized}`.split(',');
 
     document
       .querySelectorAll(`select[w-filter-select-range-from-variable="${key}"]`)
@@ -30,8 +76,11 @@ export function syncInputsFromWized(Wized) {
       });
 
     // Checkboxes
-    document.querySelectorAll(`label[w-filter-checkbox-variable="${key}"]`).forEach((label) => {
-      const text = label.querySelector('[w-filter-checkbox-label]')?.textContent || '';
+    document
+      .querySelectorAll(`label[w-filter-checkbox-variable="${key}"]`)
+      .forEach((label) => {
+        const text =
+          label.querySelector('[w-filter-checkbox-label]')?.textContent || '';
       const custom = label.querySelector('.w-checkbox-input--inputType-custom');
       if (custom) {
         if (arrValue.includes(text)) {
@@ -40,27 +89,34 @@ export function syncInputsFromWized(Wized) {
           custom.classList.remove('w--redirected-checked');
         }
       }
-    });
+      });
 
     // Radios
-    document.querySelectorAll(`label[w-filter-radio-variable="${key}"]`).forEach((label) => {
-      const text = label.querySelector('[w-filter-radio-label]')?.textContent || '';
-      const custom = label.querySelector('.w-form-formradioinput--inputType-custom');
-      if (custom) {
-        if (value === text) {
-          custom.classList.add('w--redirected-checked');
-        } else {
-          custom.classList.remove('w--redirected-checked');
+    document
+      .querySelectorAll(`label[w-filter-radio-variable="${key}"]`)
+      .forEach((label) => {
+        const text =
+          label.querySelector('[w-filter-radio-label]')?.textContent || '';
+        const custom = label.querySelector(
+          '.w-form-formradioinput--inputType-custom'
+        );
+        if (custom) {
+          if (normalized === text) {
+            custom.classList.add('w--redirected-checked');
+          } else {
+            custom.classList.remove('w--redirected-checked');
+          }
         }
-      }
-    });
+      });
   });
 }
 
 export function applyUrlParamsToWized(Wized) {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams(window.location.search);
+  const filterVars = getFilterVariableNames();
   params.forEach((value, key) => {
+    if (!filterVars.has(key)) return;
     const current = Wized.data.v[key];
     if (Array.isArray(current)) {
       Wized.data.v[key] = value ? value.split(',') : [];
@@ -78,7 +134,9 @@ export function applyUrlParamsToWized(Wized) {
 export function updateUrlFromWized(Wized) {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams();
+  const filterVars = getFilterVariableNames();
   Object.entries(Wized.data.v).forEach(([key, value]) => {
+    if (!filterVars.has(key)) return;
     if (value === null || typeof value === 'undefined') return;
     if (Array.isArray(value)) {
       if (value.length > 0) params.set(key, value.join(','));


### PR DESCRIPTION
## Summary
- detect filter variable names from DOM
- skip non-filter variables when syncing to/from the URL
- normalise `null` values to empty strings for inputs
- update URL sync unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd4a97b008322ab997b235929ef64