### PR TITLE
Fix URL sync before first request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2025-06-14
+
+### Fixed
+
+- Ensure URL parameters are applied before the first request executes and maintain normal execution when no parameters are present.
+
 ## [1.0.21] - 2025-06-14
 
 ### Fixed
@@ -23,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - There was an issue when changing radio selection, which is now fixed.
 
+[1.0.22]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.22
 [1.0.21]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.21
 [1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20
 [1.0.19]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.20",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.20",
+      "version": "1.0.22",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Summary
- ensure URL parameters are applied before the first Wized request executes
- add unit tests to confirm `initUrlSync` behavior and normal request execution when no params are present
- release version 1.0.22

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ddd5d1d088322817a0ee39b9f5205