### PR TITLE
Fix url-sync DOM readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.24] - 2025-06-14
+
+### Fixed
+
+- Defer URL parameter synchronization until DOM is ready and ensure patched requests wait for DOM readiness.
+
 ## [1.0.22] - 2025-06-14
 
 ### Fixed
@@ -29,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - There was an issue when changing radio selection, which is now fixed.
 
+[1.0.24]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.24
 [1.0.22]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.22
 [1.0.21]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.21
 [1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.22",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.22",
+      "version": "1.0.24",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.22",
+  "version": "1.0.24",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -22,7 +22,10 @@ describe('URL Sync Utilities', () => {
     if (typeof originalReadyState === 'undefined') {
       delete document.readyState;
     } else {
-      Object.defineProperty(document, 'readyState', { value: originalReadyState, configurable: true });
+      Object.defineProperty(document, 'readyState', {
+        value: originalReadyState,
+        configurable: true,
+      });
     }
     document.addEventListener = originalAddEventListener;
   });

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -8,13 +8,23 @@ function setSearch(search) {
 
 describe('URL Sync Utilities', () => {
   let originalLocation;
+  let originalReadyState;
+  let originalAddEventListener;
   beforeEach(() => {
     originalLocation = window.location;
     setSearch('');
+    originalReadyState = document.readyState;
+    originalAddEventListener = document.addEventListener;
   });
 
   afterEach(() => {
     window.location = originalLocation;
+    if (typeof originalReadyState === 'undefined') {
+      delete document.readyState;
+    } else {
+      Object.defineProperty(document, 'readyState', { value: originalReadyState, configurable: true });
+    }
+    document.addEventListener = originalAddEventListener;
   });
 
   test('applyUrlParamsToWized sets variables from query string', () => {
@@ -117,6 +127,7 @@ describe('URL Sync Utilities', () => {
     const input = document.createElement('input');
     input.setAttribute('w-filter-search-variable', 'foo');
     document.body.appendChild(input);
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
     setSearch('?foo=baz');
     const execute = jest.fn().mockResolvedValue('ok');
     const Wized = { data: { v: { foo: '' } }, requests: { execute }, on: jest.fn() };
@@ -125,6 +136,33 @@ describe('URL Sync Utilities', () => {
     const result = await Wized.requests.execute('req');
     expect(result).toBe('ok');
     expect(execute).toHaveBeenCalledWith('req');
+  });
+
+  test('initUrlSync waits for DOMContentLoaded when document is loading', async () => {
+    document.body.innerHTML = '';
+    const input = document.createElement('input');
+    input.setAttribute('w-filter-search-variable', 'foo');
+    document.body.appendChild(input);
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    const listeners = {};
+    document.addEventListener = jest.fn((evt, cb) => {
+      if (!listeners[evt]) listeners[evt] = [];
+      listeners[evt].push(cb);
+    });
+    setSearch('?foo=late');
+    const execute = jest.fn().mockResolvedValue('ok');
+    const Wized = { data: { v: { foo: '' } }, requests: { execute }, on: jest.fn() };
+    initUrlSync(Wized);
+    expect(Wized.data.v.foo).toBe('');
+
+    const execPromise = Wized.requests.execute('req');
+    expect(execute).not.toHaveBeenCalled();
+
+    listeners.DOMContentLoaded.forEach((cb) => cb());
+    const result = await execPromise;
+    expect(result).toBe('ok');
+    expect(execute).toHaveBeenCalledWith('req');
+    expect(Wized.data.v.foo).toBe('late');
   });
 
   test('patched execute behaves normally with no params', async () => {


### PR DESCRIPTION
## Summary
- defer URL parameter synchronization until DOM is ready
- wait for DOMContentLoaded before executing requests when needed
- test DOMContentLoaded handling in `UrlSync`
- bump package version to 1.0.24

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684de5f82fd88322baf1952389db3892