### PR TITLE
Fix URL param sync after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.25] - 2025-06-14
+
+### Fixed
+
+- Reapply URL parameters after full page load to override persisted values.
+
 ## [1.0.24] - 2025-06-14
 
 ### Fixed
@@ -36,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - There was an issue when changing radio selection, which is now fixed.
 
 [1.0.24]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.24
+[1.0.25]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.25
 [1.0.22]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.22
 [1.0.21]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.21
 [1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -169,5 +169,10 @@ export function initUrlSync(Wized) {
     applyOnce();
   }
 
+  // Ensure params override persisted state after all resources load
+  if (typeof window !== 'undefined') {
+    window.addEventListener('load', applyOnce, { once: true });
+  }
+
   Wized.on('requestend', () => updateUrlFromWized(Wized));
 }


### PR DESCRIPTION
## Summary
- ensure url parameter values override persisted state when the page has fully loaded
- bump version for npm publish to 1.0.25

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dec0d22808322b0bb22d3c9fef3cf