### PR TITLE
Support multiple main reset buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reapply URL parameters after full page load to override persisted values.
 
+## [1.0.26] - 2025-06-15
+
+### Added
+
+- Allow multiple `main-reset` buttons on a page.
+- Checkbox and radio resets now uncheck their underlying `<input>` elements to keep the DOM state consistent.
+
 ## [1.0.24] - 2025-06-14
 
 ### Fixed
@@ -41,8 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - There was an issue when changing radio selection, which is now fixed.
 
-[1.0.24]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.24
+[1.0.26]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.26
 [1.0.25]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.25
+[1.0.24]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.24
 [1.0.22]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.22
 [1.0.21]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.21
 [1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Although the **Sort Filter** is static, it requires a **separate div block (opti
 ## Create Reset All and its attributes list
 
 - This feature allows users to reset all active filters with a single click.
-- It requires a **single link block element**, which will act as the reset trigger.
+- It requires **one or more link block elements**, each acting as the reset trigger.
 - The following attributes must be applied to the reset link block.
   ![Webflow Screenshot](https://cdn.prod.website-files.com/657244ba4d804c29a2ef5ce0/67b69ca0335a6e59be6bc7b1_Screenshot%202025-02-20%20at%2003.07.41.png)
   ![Webflow Screenshot](https://cdn.prod.website-files.com/657244ba4d804c29a2ef5ce0/67b69ca6d0b1e9668cb7ce65_Screenshot%202025-02-20%20at%2003.07.48.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/unit/FilterCheckboxManager.test.js
+++ b/src/__tests__/unit/FilterCheckboxManager.test.js
@@ -33,6 +33,9 @@ describe('FilterCheckboxManager', () => {
             },
           };
         }
+        if (selector === 'input[type="checkbox"]') {
+          return { checked: false };
+        }
         return null;
       }),
     };
@@ -131,11 +134,17 @@ describe('FilterCheckboxManager', () => {
           remove: jest.fn(),
         },
       };
-      mockCheckbox.querySelector.mockReturnValue(customCheckbox);
+      const inputEl = { checked: false };
+      mockCheckbox.querySelector.mockImplementation((selector) => {
+        if (selector === '.w-checkbox-input--inputType-custom') return customCheckbox;
+        if (selector === 'input[type="checkbox"]') return inputEl;
+        return null;
+      });
 
       manager.updateCheckboxVisualState(mockCheckbox, true);
       expect(customCheckbox.classList.add).toHaveBeenCalledWith('w--redirected-checked');
       expect(customCheckbox.classList.remove).not.toHaveBeenCalled();
+      expect(inputEl.checked).toBe(true);
     });
 
     test('should update checkbox visual state to unchecked', () => {
@@ -145,11 +154,17 @@ describe('FilterCheckboxManager', () => {
           remove: jest.fn(),
         },
       };
-      mockCheckbox.querySelector.mockReturnValue(customCheckbox);
+      const inputEl = { checked: true };
+      mockCheckbox.querySelector.mockImplementation((selector) => {
+        if (selector === '.w-checkbox-input--inputType-custom') return customCheckbox;
+        if (selector === 'input[type="checkbox"]') return inputEl;
+        return null;
+      });
 
       manager.updateCheckboxVisualState(mockCheckbox, false);
       expect(customCheckbox.classList.remove).toHaveBeenCalledWith('w--redirected-checked');
       expect(customCheckbox.classList.add).not.toHaveBeenCalled();
+      expect(inputEl.checked).toBe(false);
     });
 
     test('should handle missing custom checkbox element', () => {

--- a/src/__tests__/unit/FilterRadioManager.test.js
+++ b/src/__tests__/unit/FilterRadioManager.test.js
@@ -30,7 +30,12 @@ describe('FilterRadioManager', () => {
             return null;
         }
       }),
-      querySelector: jest.fn(),
+      querySelector: jest.fn().mockImplementation((selector) => {
+        if (selector === 'input[type="radio"]') {
+          return { checked: false };
+        }
+        return null;
+      }),
       addEventListener: jest.fn(),
       classList: {
         add: jest.fn(),
@@ -119,10 +124,16 @@ describe('FilterRadioManager', () => {
   describe('visual state handling', () => {
     test('should update visual state correctly', () => {
       const mockCustomRadio = { classList: { add: jest.fn(), remove: jest.fn() } };
-      mockRadio.querySelector.mockReturnValue(mockCustomRadio);
+      const inputEl = { checked: false };
+      mockRadio.querySelector.mockImplementation((selector) => {
+        if (selector === '.w-form-formradioinput--inputType-custom') return mockCustomRadio;
+        if (selector === 'input[type="radio"]') return inputEl;
+        return null;
+      });
 
       manager.updateRadioVisualState(mockRadio, true);
       expect(mockCustomRadio.classList.add).toHaveBeenCalledWith('w--redirected-checked');
+      expect(inputEl.checked).toBe(true);
     });
 
     test('should handle errors in classList operations', () => {
@@ -137,7 +148,12 @@ describe('FilterRadioManager', () => {
           }),
         },
       };
-      mockRadio.querySelector.mockReturnValue(mockCustomRadio);
+      const inputEl = { checked: false };
+      mockRadio.querySelector.mockImplementation((selector) => {
+        if (selector === '.w-form-formradioinput--inputType-custom') return mockCustomRadio;
+        if (selector === 'input[type="radio"]') return inputEl;
+        return null;
+      });
 
       manager.updateRadioVisualState(mockRadio, true);
       expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/src/__tests__/unit/FilterResetManager.test.js
+++ b/src/__tests__/unit/FilterResetManager.test.js
@@ -5,7 +5,7 @@ import Wized from '../../__mocks__/wized';
 window.__TESTING__ = true;
 
 // Mock document methods
-document.querySelector = jest.fn();
+document.querySelectorAll = jest.fn();
 
 // Mock console methods
 console.log = jest.fn();
@@ -42,8 +42,8 @@ describe('FilterResetManager', () => {
       getAttribute: jest.fn(),
     };
 
-    // Setup document.querySelector mock
-    document.querySelector.mockReturnValue(mockResetButton);
+    // Setup document.querySelectorAll mock
+    document.querySelectorAll.mockReturnValue([mockResetButton]);
 
     // Create manager instance
     manager = new FilterResetManager(mockWized);
@@ -58,13 +58,13 @@ describe('FilterResetManager', () => {
       expect(manager.state).toEqual({
         initialized: true,
         processingReset: false,
-        mainResetButton: mockResetButton,
+        mainResetButtons: [mockResetButton],
       });
     });
 
     it('should not initialize twice', () => {
       manager.initialize();
-      expect(document.querySelector).toHaveBeenCalledTimes(1);
+      expect(document.querySelectorAll).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -148,9 +148,9 @@ describe('FilterResetManager', () => {
     });
 
     it('should handle missing reset button', () => {
-      document.querySelector.mockReturnValue(null);
+      document.querySelectorAll.mockReturnValue([]);
       const newManager = new FilterResetManager(mockWized);
-      expect(newManager.state.mainResetButton).toBeNull();
+      expect(newManager.state.mainResetButtons).toEqual([]);
     });
 
     it('should only reset when active filters exist', async () => {

--- a/src/filters/filter-checkbox.js
+++ b/src/filters/filter-checkbox.js
@@ -75,6 +75,11 @@ class FilterCheckboxManager {
         console.error('Error updating checkbox visual state:', error);
       }
     }
+
+    const actualInput = checkbox.querySelector('input[type="checkbox"]');
+    if (actualInput) {
+      actualInput.checked = checked;
+    }
   }
 
   // =============================================

--- a/src/filters/filter-radio.js
+++ b/src/filters/filter-radio.js
@@ -69,6 +69,11 @@ export default class FilterRadioManager {
     } else {
       console.warn('Custom radio element not found');
     }
+
+    const actualInput = radio.querySelector('input[type="radio"]');
+    if (actualInput) {
+      actualInput.checked = checked;
+    }
   }
 
   // =============================================

--- a/src/filters/filter-reset.js
+++ b/src/filters/filter-reset.js
@@ -16,7 +16,7 @@ export default class FilterResetManager {
     this.state = {
       initialized: false,
       processingReset: false, // Prevent multiple simultaneous resets
-      mainResetButton: null,
+      mainResetButtons: [],
     };
 
     // Expose global reset state
@@ -233,33 +233,35 @@ export default class FilterResetManager {
    */
   setupMainResetButton() {
     console.log('=== Setting up Reset Button ===');
-    const resetButton = document.querySelector('[w-filter-reset="main-reset"]');
-    console.log('Reset button found:', resetButton);
+    const resetButtons = document.querySelectorAll('[w-filter-reset="main-reset"]');
+    console.log('Reset buttons found:', resetButtons);
 
-    if (!resetButton) {
+    if (!resetButtons || resetButtons.length === 0) {
       console.log('No reset button found, exiting setup');
       return;
     }
 
-    this.state.mainResetButton = resetButton;
+    this.state.mainResetButtons = Array.from(resetButtons);
 
-    resetButton.addEventListener('click', async (e) => {
-      e.preventDefault();
-      console.log('=== Reset Button Click Event Started ===');
-      console.log('Event timestamp:', new Date().toISOString());
+    this.state.mainResetButtons.forEach((button) => {
+      button.addEventListener('click', async (e) => {
+        e.preventDefault();
+        console.log('=== Reset Button Click Event Started ===');
+        console.log('Event timestamp:', new Date().toISOString());
 
-      // Check if any filters are active
-      console.log('Checking for active filters...');
-      const hasActiveFilters = this.checkForActiveFilters();
-      console.log('Active filters check result:', hasActiveFilters);
+        // Check if any filters are active
+        console.log('Checking for active filters...');
+        const hasActiveFilters = this.checkForActiveFilters();
+        console.log('Active filters check result:', hasActiveFilters);
 
-      if (hasActiveFilters) {
-        console.log('Active filters found, proceeding with reset');
-        await this.resetAllFilters(resetButton);
-      } else {
-        console.log('No active filters found, skipping reset');
-      }
-      console.log('=== Reset Button Click Event Completed ===');
+        if (hasActiveFilters) {
+          console.log('Active filters found, proceeding with reset');
+          await this.resetAllFilters(button);
+        } else {
+          console.log('No active filters found, skipping reset');
+        }
+        console.log('=== Reset Button Click Event Completed ===');
+      });
     });
     console.log('Reset button setup complete');
   }


### PR DESCRIPTION
## Summary
- allow multiple elements with `w-filter-reset="main-reset"`
- checkbox and radio reset clear their underlying input elements
- bump version to 1.0.26

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ec5fb53b883228b0735b3125f3751