### PR TITLE
Fix initial request execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Checkbox and radio inputs now reflect URL parameter values by updating their `checked` state.
 
-## [1.0.29] - YYYY-MM-DD
+## [1.0.29] - 2025-06-16
 ### Added
 - Automatically execute pending requests after applying URL parameters.
+
+## [1.0.30] - 2025-06-16
+### Fixed
+- Retry initial request execution until requests become available.
  
 ## [1.0.24] - 2025-06-14
 
@@ -71,3 +75,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.20]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.20
 [1.0.19]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.19
 [1.0.29]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.29
+[1.0.30]: https://github.com/aonnoy/wized-filter-pagination/releases/tag/v1.0.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.30] - 2025-06-16
 ### Fixed
 - Retry initial request execution until requests become available.
+- Increased the polling window so late-loading requests still run.
  
 ## [1.0.24] - 2025-06-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filterandlist-for-wized",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filterandlist-for-wized",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Wized filter and pagination functionality",
   "main": "dist/index.min.js",
   "module": "dist/index.esm.js",

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -1,4 +1,9 @@
-import { applyUrlParamsToWized, updateUrlFromWized, initUrlSync } from '../../utils/url-sync.js';
+import {
+  applyUrlParamsToWized,
+  updateUrlFromWized,
+  initUrlSync,
+  executePendingRequests,
+} from '../../utils/url-sync.js';
 
 // Helper to mock window.location
 function setSearch(search) {
@@ -232,5 +237,12 @@ describe('URL Sync Utilities', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(execute).toHaveBeenCalledWith('first');
+  });
+
+  test('executePendingRequests executes when info never appears', async () => {
+    const execute = jest.fn().mockResolvedValue('ok');
+    const Wized = { data: { v: {}, r: {} }, requests: { execute }, on: jest.fn() };
+    await executePendingRequests(Wized, { requestName: 'ghost', retries: 1, delay: 10 });
+    expect(execute).toHaveBeenCalledWith('ghost');
   });
 });

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -204,4 +204,23 @@ describe('URL Sync Utilities', () => {
     expect(execute).toHaveBeenCalledTimes(1);
     expect(execute).toHaveBeenCalledWith('first');
   });
+
+  test('executePendingRequests waits for requests to appear', async () => {
+    setSearch('');
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    const execute = jest.fn().mockResolvedValue('ok');
+    const Wized = {
+      data: { v: {}, r: {} },
+      requests: { execute },
+      on: jest.fn(),
+    };
+    initUrlSync(Wized);
+    setTimeout(() => {
+      Wized.data.r.first = { hasRequested: false };
+    }, 30);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(execute).toHaveBeenCalledWith('first');
+  });
 });

--- a/src/__tests__/unit/UrlSync.test.js
+++ b/src/__tests__/unit/UrlSync.test.js
@@ -190,6 +190,11 @@ describe('URL Sync Utilities', () => {
   test('executePendingRequests runs pending requests', async () => {
     setSearch('');
     Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('w-filter-wrapper', '');
+    wrapper.setAttribute('w-filter-request', 'first');
+    document.body.appendChild(wrapper);
+
     const execute = jest.fn().mockResolvedValue('ok');
     const Wized = {
       data: {
@@ -208,6 +213,11 @@ describe('URL Sync Utilities', () => {
   test('executePendingRequests waits for requests to appear', async () => {
     setSearch('');
     Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('w-filter-wrapper', '');
+    wrapper.setAttribute('w-filter-request', 'first');
+    document.body.appendChild(wrapper);
+
     const execute = jest.fn().mockResolvedValue('ok');
     const Wized = {
       data: { v: {}, r: {} },

--- a/src/utils/url-sync.js
+++ b/src/utils/url-sync.js
@@ -150,7 +150,7 @@ export function updateUrlFromWized(Wized) {
 
 export async function executePendingRequests(
   Wized,
-  { requestName, retries = 40, delay = 50 } = {}
+  { requestName, retries = 200, delay = 50 } = {}
 ) {
   if (!Wized.requests || typeof Wized.requests.execute !== 'function') return;
 


### PR DESCRIPTION
## Summary
- improve initial request execution so pending requests run after Wized loads
- add regression test for delayed request availability
- bump package version to 1.0.30 for release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fcd0c29688322bbd8f4b1179f9169